### PR TITLE
Fail container build when curl is not successful

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/openshift/origin-machine-config-operator:4.11 as mcd
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /rpms
-RUN curl -o crio.rpm -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.24/Fedora_36/x86_64/cri-o-1.24.3-2.2.fc36.x86_64.rpm && \
-    curl -o cri-tools.rpm -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Fedora_36/x86_64/cri-tools-1.25.0-.fc36.1.1.x86_64.rpm
+RUN curl --fail -o crio.rpm -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.24/Fedora_36/x86_64/cri-o-1.24.3-2.2.fc36.x86_64.rpm && \
+    curl --fail -o cri-tools.rpm -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Fedora_36/x86_64/cri-tools-1.25.0-.fc36.1.1.x86_64.rpm
 COPY --from=artifacts /srv/repo/*.rpm /rpms/
 COPY --from=mcd /usr/bin/machine-config-daemon /binaries/machine-config-daemon


### PR DESCRIPTION
Lets update the Dockerfile to fail the container build next time curl is not successful, to catch this earlier on. References https://github.com/okd-project/okd/issues/1373.

Attempt to build the previous version (in which curl returned 404 Not Found) with this change:

```
[johan@fedora1 okd-rpms]$ podman build -t okd-rpms:4.11 .
[1/3] STEP 1/1: FROM registry.ci.openshift.org/origin/4.11:artifacts AS artifacts
--> 50734a59d8a
[2/3] STEP 1/1: FROM quay.io/openshift/origin-machine-config-operator:4.11 AS mcd
--> 4751187cb6e
[3/3] STEP 1/5: FROM registry.access.redhat.com/ubi8/ubi-minimal
[3/3] STEP 2/5: WORKDIR /rpms
--> Using cache 100b45330ec99e650aad40446c85c98d0e64415198b18f2e9e643c56c0dcf40d
--> 100b45330ec
[3/3] STEP 3/5: RUN curl --fail -o crio.rpm -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.24/Fedora_36/x86_64/cri-o-1.24.1-2.1.fc36.x86_64.rpm &&     curl --fail -o cri-tools.rpm -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Fedora_36/x86_64/cri-tools-1.24.0-.fc36.1.1.x86_64.rpm
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
Error: error building at STEP "RUN curl --fail -o crio.rpm -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.24/Fedora_36/x86_64/cri-o-1.24.1-2.1.fc36.x86_64.rpm &&     curl --fail -o cri-tools.rpm -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Fedora_36/x86_64/cri-tools-1.24.0-.fc36.1.1.x86_64.rpm": error while running runtime: exit status 22
```